### PR TITLE
Configurable repo path

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const args = require('./lib/cli')();
-const simpleGit = require('simple-git')('/home/simon/programming/javascript/others-repos/node')
-// const simpleGit = require('simple-git')('/home/simon/programming/tmp/linux')
+const simpleGit = require('simple-git')(process.argv[2])
 const moment = require('moment');
 
 const screen = require('blessed').screen();

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "blessed": "^0.1.81",
     "command-line-args": "^3.0.3",
     "command-line-usage": "^3.0.7",
+    "drawille-canvas-blessed-contrib": "^0.1.3",
     "moment": "^2.16.0",
     "simple-git": "^1.62.0"
   }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "start": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Simon Monecke",


### PR DESCRIPTION
Now one can just do: 
```npm start -- ~/path_to_repo``` 🎆 